### PR TITLE
feat(scoped-search): add command to narrow search space to a package's dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,10 @@
           "light": "resources/request-changes-light.svg",
           "dark": "resources/request-changes-dark.svg"
         }
+      },
+      {
+        "command": "vscode-monorepo-tools.scopedSearch",
+        "title": "Monorepo Tools: Scoped Search"
       }
     ],
     "views": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-monorepo-tools",
   "displayName": "vscode-monorepo-tools",
   "description": "Tools for working in monorepos.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "jcreamer",
   "repository": {
     "type": "git",

--- a/src/commands/scopedSearch.ts
+++ b/src/commands/scopedSearch.ts
@@ -1,0 +1,62 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { MonorepoDependenciesProvider } from "../dependencyProvider";
+import { QuickPickItem } from "vscode";
+import { MonorepoWorkspace } from "../dependency";
+
+export class ScopedSearchCommand {
+  treeProvider: MonorepoDependenciesProvider;
+
+  constructor(treeProvider: MonorepoDependenciesProvider) {
+    this.treeProvider = treeProvider;
+  }
+
+  async run() {
+    const workspacePackages = Array.from(this.treeProvider.items.keys());
+
+    if (!workspacePackages) {
+      return;
+    }
+
+    const quickPickItems: QuickPickItem[] = workspacePackages.map((key) => {
+      const description =
+        this.treeProvider.items.get(key)?.workspace?.description;
+      return {
+        label: key,
+        description: description,
+      };
+    });
+
+    const selectedKey = await vscode.window.showQuickPick(quickPickItems, {
+      placeHolder: "Select a package to search within",
+      canPickMany: false,
+    });
+
+    if (!selectedKey) {
+      // If the user cancels the selection, just return
+      return;
+    }
+
+    const selectedPackage = this.treeProvider.items.get(selectedKey.label);
+    if (!selectedPackage) {
+      // If there is no package data associated with the key, return
+      return;
+    }
+
+    const treeItems = this.treeProvider.getChildrenRecursively(selectedPackage);
+
+    const directoriesToInclude = treeItems
+      .map((treeItem) =>
+        path.relative(
+          this.treeProvider.workspaceRoot,
+          path.dirname(treeItem.workspace.packageJsonPath)
+        )
+      )
+      .join(", ");
+
+    // Trigger the search panel with the filesToInclude field pre-filled
+    vscode.commands.executeCommand("workbench.action.findInFiles", {
+      filesToInclude: directoriesToInclude,
+    });
+  }
+}

--- a/src/dependencyProvider.ts
+++ b/src/dependencyProvider.ts
@@ -109,6 +109,44 @@ export class MonorepoDependenciesProvider
     return [];
   }
 
+  getChildrenRecursively(element: DependencyTreeItem): DependencyTreeItem[] {
+    // Stack to process dependencies iteratively
+    const stack: string[] = [element.workspace.name];
+
+    // Track visited packages
+    const visited = new Set<string>();
+
+    // A flat list of packages that are dependencies for a given package key.
+    const dependencies: DependencyTreeItem[] = [];
+
+    // Iterate while there are packages to process in the stack
+    while (stack.length > 0) {
+      // Pop the next package key from the stack
+      const currentPackageKey = stack.pop();
+
+      // If the currentPackageKey is undefined or already visited, skip processing
+      if (currentPackageKey === undefined || visited.has(currentPackageKey)) {
+        continue;
+      }
+
+      // Mark the package as visited
+      visited.add(currentPackageKey);
+
+      // Retrieve the current package from the workspace
+      const currentPackage = this.items.get(currentPackageKey);
+
+      if (currentPackage) {
+        dependencies.push(currentPackage);
+
+        // Add its dependencies to the stack
+        const workspaceDependencies = currentPackage.workspace.children;
+        workspaceDependencies?.forEach((dep) => stack.push(dep));
+      }
+    }
+
+    return dependencies;
+  }
+
   getRootItem(items: Map<string, DependencyTreeItem>) {
     const workspaceRoot = getWorkspaceRoot(this.workspaceRoot)!;
     const workspacePackage = readJson(path.join(workspaceRoot, "package.json"));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { MonorepoDetailsProvider } from "./providers/detailsProvider";
 import { ChangeFilesProvider } from "./providers/changeFilesProvider";
 import { clearWorkspaceCache } from "./workspaces";
 import { ScoperPovider } from "./providers/scopeProvider";
+import { ScopedSearchCommand } from "./commands/scopedSearch";
 
 const pkgUp = require("pkg-up");
 
@@ -173,6 +174,8 @@ export async function activate({ subscriptions }: vscode.ExtensionContext) {
       terminal.sendText(`cd ${cwd}`);
       terminal.sendText(`yarn scoper status`);
     },
+    "vscode-monorepo-tools.scopedSearch": () =>
+      new ScopedSearchCommand(treeProvider).run(),
   };
 
   const changeTextEditorSubscription =


### PR DESCRIPTION
This PR:
- Adds a new command: `scoped-search`
- The command prefills the search filter with the package dependencies
- This feature is beneficial because it allows users to quickly narrow down the search space to a package's dependencies, making it easier to find relevant information.

I would love to get feedback on:
- [x] I am not sure if `dependencyProvider` and `DependencyTreeItem` are the right abstractions for this command. 
- [x] ~I can pre-record the demo and maybe update the README to include it? The problem is that I am on macOS, so the screen recording will look different from the other ones captured on Windows.~ **Update**: I will update README in a separate PR.