### PR TITLE
Fix search in package

### DIFF
--- a/src/commands/searchInPackage.ts
+++ b/src/commands/searchInPackage.ts
@@ -15,7 +15,7 @@ export class SearchInPackageCommand {
   }
 
   async run(node: DependencyTreeItem) {
-    const filePath = path.join(node.workspace.dir);
+    const filePath = path.dirname(node.workspace.packageJsonPath);
     vscode.commands.executeCommand("workbench.action.findInFiles", {
       query: "",
       filesToInclude: filePath,


### PR DESCRIPTION
Fixes the "Search in Packages" command, appears the `dir` property was from an older implementation and no longer exists.

Previous error: 
```
stack trace: TypeError: The "path" argument must be of type string. Received undefined
    at Object.join (node:path:1245:7)
    at SearchInPackageCommand.<anonymous> (/Users/stevendicarlo/Desktop/vscode-monorepo-tools/dist/webpack:/vscode-monorepo-tools/src/commands/searchInPackage.ts:18:22)
```

Video of corrected behavior:


https://github.com/user-attachments/assets/222d2c91-699c-469f-91cf-c10855ee38ac
